### PR TITLE
Fix regex pattern matching and demux samplesheet missing quotes on Lane column values

### DIFF
--- a/subworkflows/local/demultiplex.nf
+++ b/subworkflows/local/demultiplex.nf
@@ -50,7 +50,12 @@ workflow DEMULTIPLEX {
                                 def columns = rows[0].keySet() as List
                                 def samplesheet = file("Samplesheet_${flowcell}.csv")
                                 samplesheet.text = columns.join(',') + '\n' +
-                                    rows.collect{ r -> columns.collect { c -> r[c] }.join(',') }.join('\n')
+                                    rows.collect{ r ->
+                                        columns.collect{ c ->
+                                            def value = r[c]
+                                            c == 'Lane' ? "\"${value}\"" : value
+                                        }.join(',')
+                                    }.join('\n')
                                 [ flowcell, samplesheet ]
                         }
                         .join(

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -69,10 +69,12 @@ workflow INPUT_CHECK {
                                 def R2 = file(it['Read2File'], checkIfExists: true)
 
                                 def regexPattern = /\w\d{2}-\d+/
+                                def matcher = it.RGSM =~ regexPattern
+                                def acc = matcher.find() ? matcher.group(0) : it.RGSM
                                 def meta = [
-                                    id  : it.RGSM,
-                                    acc : (it.RGSM =~ regexPattern)?.find() ?: it.RGSM,
-                                    RGSM: it.RGSM
+                                    'id'  : it.RGSM,
+                                    'acc' : acc,
+                                    'RGSM': it.RGSM
                                 ]
 
                                 [ meta.acc, meta, [ R1, R2 ] ]


### PR DESCRIPTION
This PR fixes the following issues:
- `regexPattern` returning true instead of the value in `input_check.nf`
- flowcell specific samplesheets for demux not having quotes around values in the `Lane` column


<!--
# Clinical-Genomics-Laboratory/nf-cgl-cgs pull request

Many thanks for contributing to Clinical-Genomics-Laboratory/nf-cgl-cgs!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/Clinical-Genomics-Laboratory/nf-cgl-cgs/tree/main/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/Clinical-Genomics-Laboratory/nf-cgl-cgs/tree/main/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
